### PR TITLE
Update binding.gyp to support macOS compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,12 @@
       'defines': [
         'VERSION=0.4.6',
       ],
+      'xcode_settings': {
+        'OTHER_CFLAGS': [
+          "-std=c++11",
+          "-stdlib=libc++"
+        ],
+      },
       'sources': [
         'src/bindings.cpp',
         'src/ivrsystem.cpp',


### PR DESCRIPTION
node-gyp can't find <array> without adding C++11 support on macOS